### PR TITLE
이전 달의 데이터를 전달하는 형식으로 수정

### DIFF
--- a/src/main/java/com/humanoid/emobin/EmobinApplication.java
+++ b/src/main/java/com/humanoid/emobin/EmobinApplication.java
@@ -3,8 +3,10 @@ package com.humanoid.emobin;
 import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class EmobinApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/humanoid/emobin/domain/emotionTemperature/EmotionTemperatureService.java
+++ b/src/main/java/com/humanoid/emobin/domain/emotionTemperature/EmotionTemperatureService.java
@@ -34,11 +34,13 @@ public class EmotionTemperatureService {
         } catch (DateTimeException e) {
             throw new CustomException(EmotionErrorCode.INVALID_REQUEST);
         }
+        LocalDate lastMonthlyMonth = monthStart.minusMonths(1);
+
         LocalDate monthEnd = monthStart.withDayOfMonth(monthStart.lengthOfMonth());
 
         // 월간 요약
         MonthlySummaryEntity monthlySummary = monthlySummaryRepository
-                .findByMemberAndMonth(member, monthStart)
+                .findByMemberAndMonth(member, lastMonthlyMonth)
                 .orElse(null); // 없으면 null
 
         // 일간 요약

--- a/src/main/java/com/humanoid/emobin/domain/emotionTemperature/monthlySummary/MonthlySummaryService.java
+++ b/src/main/java/com/humanoid/emobin/domain/emotionTemperature/monthlySummary/MonthlySummaryService.java
@@ -1,6 +1,5 @@
 package com.humanoid.emobin.domain.emotionTemperature.monthlySummary;
 
-
 import com.humanoid.emobin.domain.emotionTemperature.dailySummary.DailySummaryEntity;
 import com.humanoid.emobin.domain.emotionTemperature.dailySummary.repository.DailySummaryRepository;
 import com.humanoid.emobin.domain.member.entity.Member;

--- a/src/main/java/com/humanoid/emobin/domain/emotionTemperature/monthlySummary/scheduling/MonthlySummaryScheduler.java
+++ b/src/main/java/com/humanoid/emobin/domain/emotionTemperature/monthlySummary/scheduling/MonthlySummaryScheduler.java
@@ -1,0 +1,42 @@
+package com.humanoid.emobin.domain.emotionTemperature.monthlySummary.scheduling;
+
+import com.humanoid.emobin.domain.emotionTemperature.monthlySummary.MonthlySummaryService;
+import com.humanoid.emobin.domain.member.entity.Member;
+import com.humanoid.emobin.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MonthlySummaryScheduler {
+
+    private final MonthlySummaryService monthlySummaryService;
+    private final MemberRepository memberRepository;
+
+    // 매일 새벽 2시에 실행
+    @Scheduled(cron = "0 0 2 * * *")
+    public void runMonthlySummaryTask() {
+        LocalDate today = LocalDate.now();
+        LocalDate endOfMonth = today.withDayOfMonth(today.lengthOfMonth());
+
+        if (!today.equals(endOfMonth)) {
+            log.info("오늘은 말일이 아닙니다. 실행하지 않습니다: {}", today);
+            return;
+        }
+
+        log.info("말일입니다. 월간 요약을 실행합니다: {}", today);
+
+        List<Member> members = memberRepository.findAll();
+        for (Member member : members) {
+            monthlySummaryService.updateOrCreateMonthlySummary(member, today);
+        }
+
+        log.info("모든 회원에 대한 월간 요약 작업 완료");
+    }
+}


### PR DESCRIPTION
## ✅ PR 개요

어떤 작업을 했는지 한 줄로 설명해주세요.  
api의 2025-07이라고 한다면 6월의 월간 온도와 7월의 일간 온도를 적용하도록 수정

---

## 📌 관련 이슈

- 관련 이슈: #12 

---

## 🔍 변경 사항 요약

- [x] 온도 전달 API 의 서비스 수정
- [x] 로컬의 DB를 통해서 테스트 확인

---

## 🙋‍♀️ 체크리스트

- [x] 테스트 코드 작성 및 통과 확인
- [ ] 빌드 및 기능 테스트 완료
- [x] 팀 내 코딩 컨벤션에 부합
